### PR TITLE
lock tslint version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@types/node": "^10.12.18",
     "prettier": "^1.15.3",
-    "tslint": "^5.10.0",
+    "tslint": "^5.12.0",
     "tslint-config-yoshi": "^3.22.5",
     "tslint-plugin-wix-style-react": "^1.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@types/node": "^10.12.18",
     "prettier": "^1.15.3",
-    "tslint": "^5.12.0",
+    "tslint": "5.12.0",
     "tslint-config-yoshi": "^3.22.5",
     "tslint-plugin-wix-style-react": "^1.0.3"
   },


### PR DESCRIPTION
tslint 5.13.0 added a deprecation on ruleWalker that breaks the build.